### PR TITLE
TargetClearFix

### DIFF
--- a/TargetManager.cs
+++ b/TargetManager.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TargetManager : MonoBehaviour {
+
+	public bool targetAlreadyLoaded;
+	public string sceneLoaded;
+
+
+	void Update () {
+		if (!targetAlreadyLoaded) {
+			sceneLoaded = null;
+		}
+	}
+}

--- a/TargetManager.cs.meta
+++ b/TargetManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ca3baec62eb2445518210e56b4749a72
+timeCreated: 1501087966
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a target manager. this holds the information of the currently
loaded target. This is held outside of the target game object. If
another target is loaded during the time that another target is already
loaded, it will unload the target already loaded before then loading
the new target. Confusing right? Hopefully that fixes it.